### PR TITLE
Clang/LLVM fixes for wrapper

### DIFF
--- a/arch/powerpc/boot/wrapper
+++ b/arch/powerpc/boot/wrapper
@@ -50,6 +50,7 @@ pie=
 format=
 notext=
 rodynamic=
+norelro=
 
 # cross-compilation prefix
 CROSS=
@@ -178,6 +179,21 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
+# binutils, set a reasonable default if unset
+if [ "$LLVM" = 1 ]; then
+    BIN_OBJDUMP="${OBJDUMP:-${CROSS}llvm-objdump}"
+    BIN_OBJCOPY="${OBJCOPY:-${CROSS}llvm-objcopy}"
+    BIN_NM="${NM:-${CROSS}llvm-nm}"
+    BIN_LD="${LD:-${CROSS}ld.lld}"
+    BIN_STRINGS="${STRINGS:-${CROSS}llvm-strings}"
+else
+    BIN_OBJDUMP="${OBJDUMP:-${CROSS}objdump}"
+    BIN_OBJCOPY="${OBJCOPY:-${CROSS}objcopy}"
+    BIN_NM="${NM:-${CROSS}nm}"
+    BIN_LD="${LD:-${CROSS}ld}"
+    BIN_STRINGS="${STRINGS:-${CROSS}strings}"
+fi
+
 
 if [ -n "$dts" ]; then
     if [ ! -r "$dts" -a -r "$object/dts/$dts" ]; then
@@ -193,7 +209,7 @@ if [ -z "$kernel" ]; then
     kernel=vmlinux
 fi
 
-LC_ALL=C elfformat="`${CROSS}objdump -p "$kernel" | grep 'file format' | awk '{print $4}'`"
+LC_ALL=C elfformat="`${BIN_OBJDUMP} -p "$kernel" | grep 'file format' | awk '{print $4}'`"
 case "$elfformat" in
     elf64-powerpcle)	format=elf64lppc	;;
     elf64-powerpc)	format=elf32ppc	;;
@@ -221,7 +237,7 @@ ld_version()
 
 ld_is_lld()
 {
-	${CROSS}ld -V 2>&1 | grep -q LLD
+	${BIN_LD} -V 2>&1 | grep -q LLD
 }
 
 # Do not include PT_INTERP segment when linking pie. Non-pie linking
@@ -230,7 +246,7 @@ nodl="--no-dynamic-linker"
 
 # suppress some warnings in recent ld versions
 nowarn="-z noexecstack"
-if "${CROSS}ld" -v --no-warn-rwx-segments >/dev/null 2>&1; then
+if "${BIN_LD}" -v --no-warn-rwx-segments >/dev/null 2>&1; then
 	nowarn="$nowarn --no-warn-rwx-segments"
 fi
 
@@ -349,6 +365,7 @@ xpedite52*)
 gamecube|wii)
     link_address='0x600000'
     platformo="$object/$platform-head.o $object/$platform.o"
+    norelro=$(if ld_is_lld; then echo "-z norelro"; fi)
     ;;
 microwatt)
     link_address='0x500000'
@@ -369,7 +386,7 @@ epapr)
     link_address='0x20000000'
     pie=-pie
     notext='-z notext'
-    rodynamic=$(if ${CROSS}ld -V 2>&1 | grep -q LLD ; then echo "-z rodynamic"; fi)
+    rodynamic=$(if ld_is_lld; then echo "-z rodynamic"; fi)
     ;;
 mvme5100)
     platformo="$object/fixed-head.o $object/mvme5100.o"
@@ -385,7 +402,9 @@ esac
 vmz="$tmpdir/`basename \"$kernel\"`.$ext"
 
 # Calculate the vmlinux.strip size
-${CROSS}objcopy $objflags "$kernel" "$vmz.$$"
+
+${BIN_OBJCOPY} $objflags "$kernel" "$vmz.$$"
+
 strip_size=$(${CONFIG_SHELL} "${srctree}/scripts/file-size.sh" "$vmz.$$")
 
 if [ -z "$cacheit" -o ! -f "$vmz$compression" -o "$vmz$compression" -ot "$kernel" ]; then
@@ -438,14 +457,14 @@ fi
 
 # Extract kernel version information, some platforms want to include
 # it in the image header
-version=`${CROSS}strings "$kernel" | grep '^Linux version [-0-9.]' | \
+version=`${BIN_STRINGS} "$kernel" | grep '^Linux version [-0-9.]' | \
     head -n1 | cut -d' ' -f3`
 if [ -n "$version" ]; then
     uboot_version="-n Linux-$version"
 fi
 
 # physical offset of kernel image
-membase=`${CROSS}objdump -p "$kernel" | grep -m 1 LOAD | awk '{print $7}'`
+membase=`${BIN_OBJDUMP} -p "$kernel" | grep -m 1 LOAD | awk '{print $7}'`
 
 case "$platform" in
 uboot)
@@ -460,7 +479,7 @@ uboot)
 esac
 
 addsec() {
-    ${CROSS}objcopy $4 $1 \
+    ${BIN_OBJCOPY} $4 $1 \
 	--add-section=$3="$2" \
 	--set-section-flags=$3=contents,alloc,load,readonly,data
 }
@@ -490,18 +509,18 @@ if [ "$platform" != "miboot" ]; then
         text_start="-Ttext $link_address"
     fi
 #link everything
-    ${CROSS}ld -m $format -T $lds $text_start $pie $nodl $nowarn $rodynamic $notext -o "$ofile" $map \
+    ${BIN_LD} -m $format -T $lds $text_start $pie $nodl $nowarn $rodynamic $norelro $notext -o "$ofile" $map \
 	$platformo $tmp $object/wrapper.a
     rm $tmp
 fi
 
 # Some platforms need the zImage's entry point and base address
-base=0x`${CROSS}nm "$ofile" | grep ' _start$' | cut -d' ' -f1`
-entry=`${CROSS}objdump -f "$ofile" | grep '^start address ' | cut -d' ' -f3`
+base=0x`${BIN_NM} "$ofile" | grep ' _start$' | cut -d' ' -f1`
+entry=`${BIN_OBJDUMP} -f "$ofile" | grep '^start address ' | cut -d' ' -f3`
 
 if [ -n "$binary" ]; then
     mv "$ofile" "$ofile".elf
-    ${CROSS}objcopy -O binary "$ofile".elf "$ofile"
+    ${BIN_OBJCOPY} -O binary "$ofile".elf "$ofile"
 fi
 
 # post-processing needed for some platforms
@@ -510,7 +529,7 @@ pseries|chrp)
     $objbin/addnote "$ofile"
     ;;
 coff)
-    ${CROSS}objcopy -O aixcoff-rs6000 --set-start "$entry" "$ofile"
+    ${BIN_OBJCOPY} -O aixcoff-rs6000 --set-start "$entry" "$ofile"
     $objbin/hack-coff "$ofile"
     ;;
 cuboot*)
@@ -538,18 +557,18 @@ ps3)
     # copied to offset 0x100.  At runtime the bootwrapper program copies
     # the data at __system_reset_kernel back to addr 0x100.
 
-    system_reset_overlay=0x`${CROSS}nm "$ofile" \
+    system_reset_overlay=0x`${BIN_NM} "$ofile" \
         | grep ' __system_reset_overlay$'       \
         | cut -d' ' -f1`
     system_reset_overlay=`printf "%d" $system_reset_overlay`
-    system_reset_kernel=0x`${CROSS}nm "$ofile" \
+    system_reset_kernel=0x`${BIN_NM} "$ofile" \
         | grep ' __system_reset_kernel$'       \
         | cut -d' ' -f1`
     system_reset_kernel=`printf "%d" $system_reset_kernel`
     overlay_dest="256"
     overlay_size="512"
 
-    ${CROSS}objcopy -O binary "$ofile" "$ofile.bin"
+    ${BIN_OBJCOPY} -O binary "$ofile" "$ofile.bin"
 
     run_cmd dd if="$ofile.bin" of="$ofile.bin" conv=notrunc   \
         skip=$overlay_dest seek=$system_reset_kernel          \
@@ -567,7 +586,7 @@ ps3)
     # reached, then enter the system reset vector of the partially decompressed
     # image.  No warning is issued.
     rm -f "$odir"/{otheros,otheros-too-big}.bld
-    size=$(${CROSS}nm --no-sort --radix=d "$ofile" | grep -E ' _end$' | cut -d' ' -f1)
+    size=$(${BIN_NM} --no-sort --radix=d "$ofile" | grep -E ' _end$' | cut -d' ' -f1)
     bld="otheros.bld"
     if [ $size -gt $((0x1000000)) ]; then
         bld="otheros-too-big.bld"

--- a/drivers/video/fbdev/gcnfb.c
+++ b/drivers/video/fbdev/gcnfb.c
@@ -2331,7 +2331,7 @@ static int vifb_do_remove(struct device *dev)
 }
 
 /* clean up reserved pages of the virtual framebuffer */
-static void vifb_release_virtual_fb() {
+static void vifb_release_virtual_fb(void) {
 	unsigned long size;
 	unsigned long adr = (unsigned long)vfb_mem;
 	


### PR DESCRIPTION
Modifies wrapper (the script that generates boot images) to respect the variables that define toolchain binaries if they are set.
If a toolchain isn't defined, wrapper will default to its original values. With these changes, Clang/LLVM can generate a functional zImage. This step previously failed because wrapper was trying to use the native GNU binutils.

Also fixes a warning so Clang can build without disabling `-Werror`.

Tested building with Clang/LLVM 22.1.8 and GCC 13.2.0 + boots on a real Wii.

