### PR TITLE
fix zImage linking

### DIFF
--- a/arch/powerpc/boot/wrapper
+++ b/arch/powerpc/boot/wrapper
@@ -260,7 +260,7 @@ isection=.kernel:initrd
 esection=.kernel:esm_blob
 link_address='0x400000'
 make_space=y
-
+norelro=$(if ld_is_lld; then echo "-z norelro"; fi)
 
 if [ -n "$esm_blob" -a "$platform" != "pseries" ]; then
     echo "ESM blob not support on non-pseries platforms" >&2
@@ -365,7 +365,6 @@ xpedite52*)
 gamecube|wii)
     link_address='0x600000'
     platformo="$object/$platform-head.o $object/$platform.o"
-    norelro=$(if ld_is_lld; then echo "-z norelro"; fi)
     ;;
 microwatt)
     link_address='0x500000'


### PR DESCRIPTION
All platforms need lld to use `-z norelro` when linking their zImage, or else linking fails. It isn't Wii specific. Oops.

(Wii is unaffected, obviously.)